### PR TITLE
Restructured Offix enqueue function.

### DIFF
--- a/offix-offline/src/main/java/org/aerogear/offixoffline/Offix.kt
+++ b/offix-offline/src/main/java/org/aerogear/offixoffline/Offix.kt
@@ -9,56 +9,81 @@ import com.apollographql.apollo.ApolloClient
 import com.apollographql.apollo.api.Input
 import com.apollographql.apollo.api.Mutation
 import com.apollographql.apollo.api.Operation
+import com.apollographql.apollo.api.Response
+import com.apollographql.apollo.exception.ApolloException
 import org.json.JSONObject
-import java.util.concurrent.TimeUnit
 
 /* Extension function on ApolloClient which will be used by the user while making a call request.
    @receiver parameter is ApolloClient on which the call will be made by the user.
    @param mutation which will be stored in the list if network connection is not there.
-   @param callback which will be stored in the list if network connection is not there.
+   @param offixInterface which is of type OffixInterface.
  */
 fun ApolloClient.enqueue(
     mutation: Mutation<Operation.Data, Any, Operation.Variables>,
-    callback: ApolloCall.Callback<Any>
+    offixInterface: OffixInterface
 ) {
     /* Set apollo client given by the user.
      */
     OfflineList.apClient = this
 
-    /* Check is the network is available or not.
-     */
-    if (Offline.isNetwork()) {
-        Log.d("Extension", " Network connected")
-        this.mutate(mutation).enqueue(callback)
-    } else {
-        Log.d("Extension", "Network not connected")
+    /*
+     Create an object of ApolloCall.Callback
+    */
+    val apolloCallback = object : ApolloCall.Callback<Any>() {
 
-        /* If the user is offline:
-           (For Case 1: When the app is in foreground, i.e. in-memory)
-           1. Store the mutation object and callback in an array-list.
+        /**
+         * Called when the request could not be executed due to cancellation, a connectivity problem or
+         * timeout.
          */
-        Log.d("Extension", " mutation : ${mutation.variables().valueMap()}")
-        OfflineList.getInstance().offlineArrayList.add(mutation)
-        OfflineList.getInstance().callbacksList.add(callback)
+        override fun onFailure(e: ApolloException) {
+            Log.d("Extension Callback - ", "$e")
 
-        /* If the user is offline:
-          (For Case 2: When the app is in background, we will scheduleWorker a worker to replicate the mutations stored in database to the server)
-           1. Make an object of mutation persistence class.
-           2.Store it in database
-         */
+            /* If the user is offline:
+             (For Case 1: When the app is in foreground, i.e. in-memory)
+             Store the mutation object and callback in an array-list.
+             (Callback is stored after the object is made)
+            */
+            OfflineList.getInstance().offlineArrayList.add(mutation)
 
-        /* Get access to the dao of the database
-         */
-        val libDao = getDao()
+            /* If the user is offline:
+              (For Case 2: When the app is in background, we will scheduleWorker a worker to replicate the mutations stored in database to the server)
+               1. Make an object of mutation persistence class.
+               2. Store it in database
+             */
 
-        /* Insert mutation object in the database.
-        */
-        libDao?.insertMutation(getPersistenceMutation(mutation))
-        Log.d("Extension", " serial number: ${libDao?.getAllMutations()?.get(0)?.sNo}")
-        Log.d("Extension", " values of mutation: ${libDao?.getAllMutations()?.get(0)?.valueMap}")
-        Log.d("Extension", " size of db list after inserting mutations: ${libDao?.getAllMutations()?.size}")
+            /* Get access to the dao of the database
+             */
+            val libDao = getDao()
+
+            /* Insert mutation object in the database.
+            */
+            libDao?.insertMutation(getPersistenceMutation(mutation))
+            Log.d("Extension", " serial number: ${libDao?.getAllMutations()?.get(0)?.sNo}")
+            Log.d("Extension", " size of db list after inserting mutations: ${libDao?.getAllMutations()?.size}")
+
+            /*
+             Set the exception that caused onFailure() and the mutation object in the onSchedule() of offixInterface.
+             */
+            offixInterface.onSchedule(e, mutation)
+        }
+
+        override fun onResponse(response: Response<Any>) {
+            val result = response.data().toString()
+            Log.d("Extension Callback * ", result)
+
+            /*
+             Set the response received from the server in the onSucceess() of offixInterface.
+             */
+            offixInterface.onSuccess(response)
+        }
     }
+
+    /*
+      Make a call with the mutation to the server.
+     */
+    this.mutate(mutation).enqueue(apolloCallback)
 }
+
 
 /*
  This function takes in an object of Mutation<D,T,V> and returns an object of com.aerogear.offix.persistence.Mutation.

--- a/offix-offline/src/main/java/org/aerogear/offixoffline/Offix.kt
+++ b/offix-offline/src/main/java/org/aerogear/offixoffline/Offix.kt
@@ -16,11 +16,11 @@ import org.json.JSONObject
 /* Extension function on ApolloClient which will be used by the user while making a call request.
    @receiver parameter is ApolloClient on which the call will be made by the user.
    @param mutation which will be stored in the list if network connection is not there.
-   @param offixInterface which is of type OffixInterface.
+   @param responseCallback which is of type ResponseCallback.
  */
 fun ApolloClient.enqueue(
     mutation: Mutation<Operation.Data, Any, Operation.Variables>,
-    offixInterface: OffixInterface
+    responseCallback: ResponseCallback
 ) {
     /* Set apollo client given by the user.
      */
@@ -61,9 +61,9 @@ fun ApolloClient.enqueue(
             Log.d("Extension", " size of db list after inserting mutations: ${libDao?.getAllMutations()?.size}")
 
             /*
-             Set the exception that caused onFailure() and the mutation object in the onSchedule() of offixInterface.
+             Set the exception that caused onFailure() and the mutation object in the onSchedule() of responseCallback.
              */
-            offixInterface.onSchedule(e, mutation)
+            responseCallback.onSchedule(e, mutation)
         }
 
         override fun onResponse(response: Response<Any>) {
@@ -71,9 +71,9 @@ fun ApolloClient.enqueue(
             Log.d("Extension Callback * ", result)
 
             /*
-             Set the response received from the server in the onSucceess() of offixInterface.
+             Set the response received from the server in the onSucceess() of responseCallback.
              */
-            offixInterface.onSuccess(response)
+            responseCallback.onSuccess(response)
         }
     }
 

--- a/offix-offline/src/main/java/org/aerogear/offixoffline/Offix.kt
+++ b/offix-offline/src/main/java/org/aerogear/offixoffline/Offix.kt
@@ -40,8 +40,7 @@ fun ApolloClient.enqueue(
 
             /* If the user is offline:
              (For Case 1: When the app is in foreground, i.e. in-memory)
-             Store the mutation object and callback in an array-list.
-             (Callback is stored after the object is made)
+             Store the mutation object in an array-list.
             */
             OfflineList.getInstance().offlineArrayList.add(mutation)
 

--- a/offix-offline/src/main/java/org/aerogear/offixoffline/OffixInterface.kt
+++ b/offix-offline/src/main/java/org/aerogear/offixoffline/OffixInterface.kt
@@ -5,7 +5,7 @@ import com.apollographql.apollo.api.Operation
 import com.apollographql.apollo.api.Response
 import com.apollographql.apollo.exception.ApolloException
 
-/*
+/**
  OffixInterface is used by the users in making a callback object which is passed to the Offix enqueue() function.
  */
 interface OffixInterface {

--- a/offix-offline/src/main/java/org/aerogear/offixoffline/OffixInterface.kt
+++ b/offix-offline/src/main/java/org/aerogear/offixoffline/OffixInterface.kt
@@ -1,0 +1,20 @@
+package org.aerogear.offixoffline
+
+import com.apollographql.apollo.api.Mutation
+import com.apollographql.apollo.api.Operation
+import com.apollographql.apollo.api.Response
+import com.apollographql.apollo.exception.ApolloException
+
+interface OffixInterface {
+
+    /**
+     * Called when the request is successfully executed and we get the response from the server.
+     */
+    fun onSuccess(response: Response<Any>)
+
+    /**
+     * Called when the request could not be executed due to cancellation, a connectivity problem or
+     * timeout.
+     */
+    fun onSchedule(e: ApolloException, mutation: Mutation<Operation.Data, Any, Operation.Variables>)
+}

--- a/offix-offline/src/main/java/org/aerogear/offixoffline/OffixInterface.kt
+++ b/offix-offline/src/main/java/org/aerogear/offixoffline/OffixInterface.kt
@@ -5,6 +5,9 @@ import com.apollographql.apollo.api.Operation
 import com.apollographql.apollo.api.Response
 import com.apollographql.apollo.exception.ApolloException
 
+/*
+ OffixInterface is used by the users in making a callback object which is passed to the Offix enqueue() function.
+ */
 interface OffixInterface {
 
     /**

--- a/offix-offline/src/main/java/org/aerogear/offixoffline/OffixInterface.kt
+++ b/offix-offline/src/main/java/org/aerogear/offixoffline/OffixInterface.kt
@@ -9,7 +9,6 @@ import com.apollographql.apollo.exception.ApolloException
  OffixInterface is used by the users in making a callback object which is passed to the Offix enqueue() function.
  */
 interface OffixInterface {
-
     /**
      * Called when the request is successfully executed and we get the response from the server.
      */

--- a/offix-offline/src/main/java/org/aerogear/offixoffline/OfflineSyncService.kt
+++ b/offix-offline/src/main/java/org/aerogear/offixoffline/OfflineSyncService.kt
@@ -3,6 +3,9 @@ package org.aerogear.offixoffline
 import android.app.IntentService
 import android.content.Intent
 import android.util.Log
+import com.apollographql.apollo.ApolloCall
+import com.apollographql.apollo.api.Response
+import com.apollographql.apollo.exception.ApolloException
 
 /* Start a service from broadcast receiver which hits mutation to the server.
  */
@@ -24,30 +27,42 @@ class OfflineSyncService : IntentService("OfflineService") {
         val isNetworkAvail = Offline.isNetwork()
 
         val mutationList = OfflineList.getInstance().offlineArrayList
-        val callbackList = OfflineList.getInstance().callbacksList
         val apolloClient = OfflineList.apClient
+
+        /*
+          Create an object of ApolloCall.Callback
+         */
+        val apolloCallback = object : ApolloCall.Callback<Any>() {
+            override fun onFailure(e: ApolloException) {
+                Log.d("Extension Callback - ", "$e")
+            }
+
+            override fun onResponse(response: Response<Any>) {
+                Log.d(TAG, response.data().toString())
+            }
+        }
 
         mutationList.forEachIndexed { index, currentMutation ->
             if (isNetworkAvail) {
                 Log.d(TAG, "Network Connected :  $isNetworkAvail")
-                val currentCallback = callbackList[index]
-                apolloClient?.mutate(currentMutation)?.enqueue(currentCallback)
+                apolloClient?.mutate(currentMutation)?.enqueue(apolloCallback)
             } else {
                 Log.d(TAG, "Network Connected :  $isNetworkAvail")
             }
-
-            /* Remove callbacks and mutations
-            */
-            mutationList.clear()
-            callbackList.clear()
-
-            /* Delete the mutations stored in the database as they have already been replicated to the server
-               via the array list method having mutations and callbacks because the app was still in foreground.
-               (This service starts when the app is in foreground, so no need to take the database approach here.)
-            */
-            Offline.getDb()?.mutationDao()?.deleteAllMutations()
-            Log.d(TAG, " Size of database list : ${Offline.getDb()?.mutationDao()?.getAllMutations()?.size}")
         }
+
+        /*
+         Remove mutations
+        */
+        mutationList.clear()
+
+
+        /* Delete the mutations stored in the database as they have already been replicated to the server
+           via the array list method having mutations and callbacks because the app was still in foreground.
+           (This service starts when the app is in foreground, so no need to take the database approach here.)
+        */
+        Offline.getDb()?.mutationDao()?.deleteAllMutations()
+        Log.d(TAG, " Size of database list : ${Offline.getDb()?.mutationDao()?.getAllMutations()?.size}")
     }
 }
 

--- a/offix-offline/src/main/java/org/aerogear/offixoffline/ResponseCallback.kt
+++ b/offix-offline/src/main/java/org/aerogear/offixoffline/ResponseCallback.kt
@@ -6,9 +6,9 @@ import com.apollographql.apollo.api.Response
 import com.apollographql.apollo.exception.ApolloException
 
 /**
- OffixInterface is used by the users in making a callback object which is passed to the Offix enqueue() function.
+ ResponseCallback is used by the users in making a callback object which is passed to the Offix enqueue() function.
  */
-interface OffixInterface {
+interface ResponseCallback {
     /**
      * Called when the request is successfully executed and we get the response from the server.
      */

--- a/sample/src/main/java/org/aerogear/graphqlandroid/Utils.kt
+++ b/sample/src/main/java/org/aerogear/graphqlandroid/Utils.kt
@@ -2,7 +2,6 @@
 package org.aerogear.graphqlandroid
 
 import android.content.Context
-import android.net.ConnectivityManager
 import android.support.v7.app.AppCompatActivity
 import android.util.Log
 import android.widget.Toast
@@ -21,14 +20,13 @@ import com.apollographql.apollo.interceptor.ApolloInterceptorChain
 import com.apollographql.apollo.subscription.WebSocketSubscriptionTransport
 import okhttp3.Interceptor
 import okhttp3.OkHttpClient
-import org.aerogear.graphqlandroid.activities.MainActivity
 import java.nio.charset.Charset
 import java.util.concurrent.Executor
 
 object Utils {
 
     //To run on emulator
-    const val BASE_URL = "http://192.168.0.104:4000/graphql"
+    const val BASE_URL = "http://192.168.0.101:4000/graphql"
     private const val SQL_CACHE_NAME = "tasks3Db"
 
     private var apClient: ApolloClient? = null

--- a/sample/src/main/java/org/aerogear/graphqlandroid/data/UserData.kt
+++ b/sample/src/main/java/org/aerogear/graphqlandroid/data/UserData.kt
@@ -2,7 +2,6 @@ package org.aerogear.graphqlandroid.data
 
 import android.content.Context
 import android.util.Log
-import android.widget.Toast
 import com.apollographql.apollo.ApolloCall
 import com.apollographql.apollo.ApolloCall.Callback
 import com.apollographql.apollo.ApolloQueryWatcher
@@ -13,11 +12,9 @@ import com.apollographql.apollo.cache.normalized.ApolloStore
 import com.apollographql.apollo.exception.ApolloException
 import com.apollographql.apollo.fetcher.ApolloResponseFetchers
 import org.aerogear.graphqlandroid.*
-import org.aerogear.graphqlandroid.activities.MainActivity
 import org.aerogear.graphqlandroid.model.Task
-import org.aerogear.offixoffline.OffixInterface
+import org.aerogear.offixoffline.ResponseCallback
 import org.aerogear.offixoffline.enqueue
-import java.lang.Exception
 import java.util.concurrent.atomic.AtomicReference
 
 class UserData(val context: Context) {
@@ -87,7 +84,7 @@ class UserData(val context: Context) {
         Log.e(TAG, " updateTask 23: - ${client?.operation()?.variables()?.valueMap()}")
         Log.e(TAG, " updateTask 25: - ${client?.operation()?.name()}")
 
-        val customCallback = object : OffixInterface {
+        val customCallback = object : ResponseCallback {
             override fun onSuccess(response: Response<Any>) {
                 Log.e("onSuccess() updateTask", "${response.data()}")
             }
@@ -109,7 +106,7 @@ class UserData(val context: Context) {
         Log.e(TAG, "inside create title")
         val mutation = CreateTaskMutation.builder().title(title).description(description).build()
 
-        val customCallback = object : OffixInterface {
+        val customCallback = object : ResponseCallback {
             override fun onSuccess(response: Response<Any>) {
                 Log.e("onSuccess() createTask", "${response.data()}")
             }
@@ -141,7 +138,7 @@ class UserData(val context: Context) {
             }
         }
 
-        val customCallback = object : OffixInterface {
+        val customCallback = object : ResponseCallback {
             override fun onSuccess(response: Response<Any>) {
                 Log.e("onSuccess() deleteTask", "${response.data()}")
             }

--- a/sample/src/main/java/org/aerogear/graphqlandroid/data/UserData.kt
+++ b/sample/src/main/java/org/aerogear/graphqlandroid/data/UserData.kt
@@ -2,17 +2,22 @@ package org.aerogear.graphqlandroid.data
 
 import android.content.Context
 import android.util.Log
+import android.widget.Toast
 import com.apollographql.apollo.ApolloCall
 import com.apollographql.apollo.ApolloCall.Callback
 import com.apollographql.apollo.ApolloQueryWatcher
+import com.apollographql.apollo.api.Mutation
 import com.apollographql.apollo.api.Operation
 import com.apollographql.apollo.api.Response
 import com.apollographql.apollo.cache.normalized.ApolloStore
 import com.apollographql.apollo.exception.ApolloException
 import com.apollographql.apollo.fetcher.ApolloResponseFetchers
 import org.aerogear.graphqlandroid.*
+import org.aerogear.graphqlandroid.activities.MainActivity
 import org.aerogear.graphqlandroid.model.Task
+import org.aerogear.offixoffline.OffixInterface
 import org.aerogear.offixoffline.enqueue
+import java.lang.Exception
 import java.util.concurrent.atomic.AtomicReference
 
 class UserData(val context: Context) {
@@ -82,24 +87,20 @@ class UserData(val context: Context) {
         Log.e(TAG, " updateTask 23: - ${client?.operation()?.variables()?.valueMap()}")
         Log.e(TAG, " updateTask 25: - ${client?.operation()?.name()}")
 
-        val callback = object : ApolloCall.Callback<UpdateCurrentTaskMutation.Data>() {
-            override fun onFailure(e: ApolloException) {
-                Log.e("onFailure" + "updateTask", e.toString())
+        val customCallback = object : OffixInterface {
+            override fun onSuccess(response: Response<Any>) {
+                Log.e("onSuccess() updateTask", "${response.data()}")
             }
 
-            override fun onResponse(response: Response<UpdateCurrentTaskMutation.Data>) {
-                val result = response.data()?.updateTask()
-                Log.e(TAG, "onResponse-UpdateTask")
-                Log.e(TAG, "${result?.id()}")
-                Log.e(TAG, "${result?.title()}")
-                Log.e(TAG, "${result?.description()}")
-                Log.e(TAG, "${result?.version()}")
+            override fun onSchedule(e: ApolloException, mutation: Mutation<Operation.Data, Any, Operation.Variables>) {
+                Log.e("onSchedule() updateTask", "${mutation.variables().valueMap()}")
+                e.printStackTrace()
             }
         }
 
         Utils.getApolloClient(context)?.enqueue(
             mutation as com.apollographql.apollo.api.Mutation<Operation.Data, Any, Operation.Variables>,
-            callback as ApolloCall.Callback<Any>
+            customCallback
         )
     }
 
@@ -108,24 +109,20 @@ class UserData(val context: Context) {
         Log.e(TAG, "inside create title")
         val mutation = CreateTaskMutation.builder().title(title).description(description).build()
 
-        val callback = object : ApolloCall.Callback<CreateTaskMutation.Data>() {
-            override fun onFailure(e: ApolloException) {
-                Log.e("onFailure" + "updateTask", e.toString())
+        val customCallback = object : OffixInterface {
+            override fun onSuccess(response: Response<Any>) {
+                Log.e("onSuccess() createTask", "${response.data()}")
             }
 
-            override fun onResponse(response: Response<CreateTaskMutation.Data>) {
-                val result = response.data()?.createTask()
-                Log.e(TAG, "onResponse-UpdateTask")
-                Log.e(TAG, "${result?.id()}")
-                Log.e(TAG, "${result?.title()}")
-                Log.e(TAG, "${result?.description()}")
-                Log.e(TAG, "${result?.version()}")
+            override fun onSchedule(e: ApolloException, mutation: Mutation<Operation.Data, Any, Operation.Variables>) {
+                e.printStackTrace()
+                Log.e("onSchedule() createTask", "${mutation.variables().valueMap()}")
             }
         }
 
         Utils.getApolloClient(context)?.enqueue(
             mutation as com.apollographql.apollo.api.Mutation<Operation.Data, Any, Operation.Variables>,
-            callback as ApolloCall.Callback<Any>
+            customCallback
         )
     }
 
@@ -144,9 +141,20 @@ class UserData(val context: Context) {
             }
         }
 
+        val customCallback = object : OffixInterface {
+            override fun onSuccess(response: Response<Any>) {
+                Log.e("onSuccess() deleteTask", "${response.data()}")
+            }
+
+            override fun onSchedule(e: ApolloException, mutation: Mutation<Operation.Data, Any, Operation.Variables>) {
+                e.printStackTrace()
+                Log.e("onSchedule() deleteTask", "${mutation.variables().valueMap()}")
+            }
+        }
+
         Utils.getApolloClient(context)?.enqueue(
             mutation as com.apollographql.apollo.api.Mutation<Operation.Data, Any, Operation.Variables>,
-            callback as ApolloCall.Callback<Any>
+            customCallback
         )
     }
 

--- a/sample/src/main/java/org/aerogear/graphqlandroid/data/ViewModel.kt
+++ b/sample/src/main/java/org/aerogear/graphqlandroid/data/ViewModel.kt
@@ -21,8 +21,6 @@ import kotlin.collections.ArrayList
 class ViewModel(application: Application) :
     AndroidViewModel(application) {
     val apcontext = application
-    lateinit var apolloQueryWatcher: ApolloQueryWatcher<AllTasksQuery.Data>
-    lateinit var tasksList: LiveData<List<Task>>
 
     val TAG = javaClass.simpleName
 


### PR DESCRIPTION
### Description

Fix #69 

### How it is achieved

- `enqueue` function in the Offix File.

```kotlin
/* Extension function on ApolloClient which will be used by the user while making a call request.
   @receiver parameter is ApolloClient on which the call will be made by the user.
   @param mutation which will be stored in the list if network connection is not there.
   @param offixInterface which is of type OffixInterface.
 */
fun ApolloClient.enqueue(
    mutation: Mutation<Operation.Data, Any, Operation.Variables>,
    offixInterface: OffixInterface
) {
    // Set apollo client given by the user.
    OfflineList.apClient = this
  
   //  Create an object of ApolloCall.Callback
    val apolloCallback = object : ApolloCall.Callback<Any>() {

    /** Called when the request could not be executed due to cancellation, a connectivity problem or 
         timeout.
   */
        override fun onFailure(e: ApolloException) {
   /* If the user is offline:
             (For Case 1: When the app is in foreground, i.e. in-memory)
             Store the mutation objectin an array-list.
   */
            OfflineList.getInstance().offlineArrayList.add(mutation)

  /* If the user is offline:
    (For Case 2: When the app is in the background, we will scheduleWorker a worker to replicate the 
     mutations stored in the database to the server)
 */
            // Get access to the dao of the database
            val libDao = getDao()

            // Insert mutation object in the database.
            libDao?.insertMutation(getPersistenceMutation(mutation))
      
// Set the exception that caused onFailure() and the mutation object in the onSchedule() of offixInterface.
            offixInterface.onSchedule(e, mutation)
        }

        override fun onResponse(response: Response<Any>) {
      // Set the response received from the server in the success() of offixInterface.
       offixInterface.onSuccess(response)
        }
 }

     // Make a call with the mutation to the server.
    this.mutate(mutation).enqueue(apolloCallback)
}
```


- This is used by client in this way: 

```kotlin
          //Make an object of OffixInterface
          val customCallback = object : OffixInterface {
            override fun onSuccess(response: Response<Any>) {
                Log.e("onSuccess() createTask", "${response.data()}")
                // Client can perform UI bindings here.
            }

            override fun onSchedule(e: ApolloException, mutation: Mutation<Operation.Data, Any, 
            Operation.Variables>) {
                e.printStackTrace()
             // Client can perform UI bindings here even if the network calls fail as they have access to 
                the **mutation** object here which they can use accordingly.
            }
  }

        Utils.getApolloClient(context)?.enqueue(
            mutation as com.apollographql.apollo.api.Mutation<Operation.Data, Any, 
           Operation.Variables>, customCallback
        )
```


Also, there is no need for maintaining a static array list of mutations. Instead for the foreground part, we can make an object of `ApolloCall.Callback<>()` in the `OfflineSyncService` and use it for all the calls to the server.