### PR TITLE
fix : created a queue of callbacks in conflictinterceptor

### DIFF
--- a/offix/src/main/java/org/aerogear/offix/interceptor/ConflictInterceptor.kt
+++ b/offix/src/main/java/org/aerogear/offix/interceptor/ConflictInterceptor.kt
@@ -49,7 +49,7 @@ class ConflictInterceptor(private val conflictResolutionImpl: ConfliceResolution
     inner class OffixConflictCallback(val conflictResolutionImpl: ConfliceResolutionInterface) :
         ApolloInterceptor.CallBack {
         private val TAG = javaClass.simpleName
-        private lateinit var userCallback: ApolloInterceptor.CallBack
+        val userCallback = queueCallback.removeFirst()
 
         override fun onResponse(response: ApolloInterceptor.InterceptorResponse) {
 
@@ -68,7 +68,6 @@ class ConflictInterceptor(private val conflictResolutionImpl: ConfliceResolution
 
                 conflictResolutionImpl.resolveConflict(serverStateMap, clientStateMap, conflictedMutationClass)
             } else {
-                userCallback=  queueCallback.removeFirst()
                 userCallback.onResponse(response)
             }
         }

--- a/offix/src/main/java/org/aerogear/offix/interceptor/ConflictInterceptor.kt
+++ b/offix/src/main/java/org/aerogear/offix/interceptor/ConflictInterceptor.kt
@@ -16,7 +16,6 @@ import java.util.concurrent.Executor
 class ConflictInterceptor(private val conflictResolutionImpl: ConfliceResolutionInterface) : ApolloInterceptor {
 
     private val TAG = javaClass.simpleName
-    private lateinit var userCallback: ApolloInterceptor.CallBack
 
     /* Implemented queue using a linked list to store user callbacks.
        This is done to ensure that there is no overlapping of subsequent callbacks and every callback is associated with
@@ -30,6 +29,7 @@ class ConflictInterceptor(private val conflictResolutionImpl: ConfliceResolution
         dispatcher: Executor,
         callBack: ApolloInterceptor.CallBack
     ) {
+
         queueCallback.addLast(callBack)
 
         //Check if this is a mutation request.
@@ -49,6 +49,7 @@ class ConflictInterceptor(private val conflictResolutionImpl: ConfliceResolution
     inner class OffixConflictCallback(val conflictResolutionImpl: ConfliceResolutionInterface) :
         ApolloInterceptor.CallBack {
         private val TAG = javaClass.simpleName
+        private lateinit var userCallback: ApolloInterceptor.CallBack
 
         override fun onResponse(response: ApolloInterceptor.InterceptorResponse) {
 

--- a/sample/src/main/java/org/aerogear/graphqlandroid/activities/MainActivity.kt
+++ b/sample/src/main/java/org/aerogear/graphqlandroid/activities/MainActivity.kt
@@ -244,7 +244,6 @@ class MainActivity : AppCompatActivity() {
         Toast.makeText(this, "Mutation with title $title created", Toast.LENGTH_SHORT).show()
     }
 
-
     /*
      In the activity's onStop(), schedule a worker that would try to replicate the mutations done when offline (stored in database )
      to the server whenever network connection is regained.


### PR DESCRIPTION
### Description 
 Implemented queue using a linked list to store user callbacks.
 This is done to ensure that there is no overlapping of subsequent callbacks and every callback is associated with its correct response.
